### PR TITLE
Add tcp keepalive controls on client connections

### DIFF
--- a/pollon.go
+++ b/pollon.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"time"
 )
 
 type ConfData struct {
@@ -34,6 +35,11 @@ type Proxy struct {
 	stop       chan struct{}
 	endCh      chan error
 	connMutex  sync.Mutex
+
+	keepAlive         bool
+	keepAliveIdle     time.Duration
+	keepAliveCount    int
+	keepAliveInterval time.Duration
 }
 
 func NewProxy(listener *net.TCPListener) (*Proxy, error) {
@@ -134,6 +140,12 @@ func (p *Proxy) accepter() {
 			p.endCh <- fmt.Errorf("accept error: %v", err)
 			return
 		}
+		if p.keepAlive {
+			if err := p.SetupKeepAlive(conn); err != nil {
+				p.endCh <- fmt.Errorf("setKeepAlive error: %v", err)
+				return
+			}
+		}
 		go p.proxyConn(conn)
 	}
 }
@@ -151,4 +163,20 @@ func (p *Proxy) Start() error {
 		return fmt.Errorf("proxy error: %v", err)
 	}
 	return nil
+}
+
+func (p *Proxy) SetKeepAlive(keepalive bool) {
+	p.keepAlive = keepalive
+}
+
+func (p *Proxy) SetKeepAliveIdle(d time.Duration) {
+	p.keepAliveIdle = d
+}
+
+func (p *Proxy) SetKeepAliveCount(n int) {
+	p.keepAliveCount = n
+}
+
+func (p *Proxy) SetKeepAliveInterval(d time.Duration) {
+	p.keepAliveInterval = d
 }

--- a/tcpkeepalive.go
+++ b/tcpkeepalive.go
@@ -1,0 +1,31 @@
+// +build go1.9
+
+package pollon
+
+import (
+	"net"
+
+	"github.com/sorintlab/tcpkeepalive"
+)
+
+func (p *Proxy) SetupKeepAlive(conn *net.TCPConn) error {
+	if err := conn.SetKeepAlive(true); err != nil {
+		return err
+	}
+	if p.keepAliveIdle != 0 {
+		if err := tcpkeepalive.SetKeepAliveIdle(conn, p.keepAliveIdle); err != nil {
+			return err
+		}
+	}
+	if p.keepAliveCount != 0 {
+		if err := tcpkeepalive.SetKeepAliveCount(conn, p.keepAliveCount); err != nil {
+			return err
+		}
+	}
+	if p.keepAliveInterval != 0 {
+		if err := tcpkeepalive.SetKeepAliveInterval(conn, p.keepAliveInterval); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/tcpkeepalive_go18.go
+++ b/tcpkeepalive_go18.go
@@ -1,0 +1,14 @@
+// +build go1.8,!go1.9
+
+package pollon
+
+import "net"
+
+func (p *Proxy) SetupKeepAlive(conn *net.TCPConn) error {
+	if err := conn.SetKeepAlive(true); err != nil {
+		return err
+	}
+	// ignore fine grained keepalive parameters since they are not supported
+
+	return nil
+}


### PR DESCRIPTION
This patch adds the ability to enable tcp keepalive on client connections and
options to fine tune tpc keepalive socket parameters (idle, count and interval).

The fine tuning of tcp keepalive socket parameters works only with go >= 1.9 and
it's ignored for previous go versions.