### PR TITLE
Cancel net.Dial when destination change

### DIFF
--- a/pollon.go
+++ b/pollon.go
@@ -68,11 +68,14 @@ func (p *Proxy) proxyConn(conn *net.TCPConn) {
 		return
 	}
 
-	destConn, err := net.DialTCP("tcp", nil, p.destAddr)
+	var d net.Dialer
+	d.Cancel = closeConns
+	destConnInterface, err := d.Dial("tcp", destAddr.String())
 	if err != nil {
 		conn.Close()
 		return
 	}
+	destConn := destConnInterface.(*net.TCPConn)
 	defer func() {
 		log.Printf("closing destination connection: %v", destConn)
 		destConn.Close()


### PR DESCRIPTION
See https://github.com/sorintlab/stolon/issues/365.

net.Dial may hang, this PR replace it with cancelable Dialer.Dial(). It is canceled by closeConns.

It also use local destAddr variable instead of p.destAddr. I think it was expected to use the local destAddr variable that was taken under the lock instead of p.destAddr which could be modified by another thread.